### PR TITLE
💄  Feat:Implementação da rota de put para status da ong

### DIFF
--- a/src/main/java/com/adotai/backend_adotai/controller/AnimalController.java
+++ b/src/main/java/com/adotai/backend_adotai/controller/AnimalController.java
@@ -5,10 +5,7 @@ import com.adotai.backend_adotai.dto.Api.ResponseApi;
 import com.adotai.backend_adotai.service.AnimalService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @Controller
 @RequestMapping("/animal")
@@ -31,4 +28,9 @@ public class AnimalController {
         return ResponseEntity.status(response.status()).body(response);
     }
 
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ResponseApi> deleteById(@PathVariable int id){
+        ResponseApi response = animalService.deleteById(id);
+        return ResponseEntity.status(response.status()).body(response);
+    }
 }

--- a/src/main/java/com/adotai/backend_adotai/controller/OngController.java
+++ b/src/main/java/com/adotai/backend_adotai/controller/OngController.java
@@ -38,4 +38,10 @@ public class OngController {
         ResponseApi response = ongService.delete(id);
         return ResponseEntity.status(response.status()).body(response);
     }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ResponseApi> updateStatusById(@PathVariable int id){
+        ResponseApi response = ongService.updateStatusById(id);
+        return ResponseEntity.status(response.status()).body(response);
+    }
 }

--- a/src/main/java/com/adotai/backend_adotai/repository/OngRepository.java
+++ b/src/main/java/com/adotai/backend_adotai/repository/OngRepository.java
@@ -1,10 +1,19 @@
 package com.adotai.backend_adotai.repository;
 
 import com.adotai.backend_adotai.entity.Ong;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface OngRepository extends JpaRepository<Ong,Integer> {
     Optional<Ong> findByEmail(String email);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Ong o SET o.status = NOT o.status WHERE o.id = :id")
+    int toggleStatusById(@Param("id") int id);
 }

--- a/src/main/java/com/adotai/backend_adotai/service/AnimalService.java
+++ b/src/main/java/com/adotai/backend_adotai/service/AnimalService.java
@@ -3,8 +3,10 @@ package com.adotai.backend_adotai.service;
 import com.adotai.backend_adotai.dto.Animal.Request.RequestAnimalDto;
 import com.adotai.backend_adotai.dto.Animal.Response.ResponseAnimalDto;
 import com.adotai.backend_adotai.dto.Api.ResponseApi;
+import com.adotai.backend_adotai.dto.Ong.Response.ResponseOngDTO;
 import com.adotai.backend_adotai.entity.*;
 import com.adotai.backend_adotai.mapper.AnimalMapper;
+import com.adotai.backend_adotai.mapper.OngMapper;
 import com.adotai.backend_adotai.repository.*;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
@@ -96,6 +98,22 @@ public class AnimalService {
                     Color newColor = new Color(name);
                     return colorRepository.save(newColor);
                 });
+    }
+
+    public ResponseApi deleteById(int id){
+        Optional<Animal> animal = animalRepository.findById(id);
+
+        if(animal.isEmpty())
+            return ResponseApi.error(404,"Ong not found.");
+
+        try{
+            animalRepository.deleteById(id);
+            ResponseAnimalDto dto = AnimalMapper.toDto(animal.get());
+
+            return ResponseApi.success("Success",dto);
+        } catch (Exception e) {
+            return ResponseApi.error(500,"Error: " + e.getMessage());
+        }
     }
 
 }

--- a/src/main/java/com/adotai/backend_adotai/service/OngService.java
+++ b/src/main/java/com/adotai/backend_adotai/service/OngService.java
@@ -113,4 +113,12 @@ public class OngService {
             return ResponseApi.error(500,"Error: " + e.getMessage());
         }
     }
+
+    public ResponseApi<?> updateStatusById(int id){
+        int rowsAffected = ongRepository.toggleStatusById(id);
+        if (rowsAffected == 0){
+            return ResponseApi.error(404,"Not Found");
+        }
+        return ResponseApi.success("Success",null);
+    }
 }


### PR DESCRIPTION
**🛠️ Implementação da Rota PUT para Alternar o Status da ONG**
**Objetivo:**
Criar uma rota PUT que permite alternar o status (true/false) da entidade Ong com base no ID recebido como parâmetro.

Implementações Realizadas:

Criação do método toggleStatusById(int id) no repositório OngRepository utilizando a anotação @Modifying.

Implementação do método toggleOngStatus(int id) no serviço OngService, que executa a lógica de atualização de status sem carregar a entidade completa.

Criação do endpoint /ongs/{id}/toggle-status no controlador OngController, permitindo a alteração do status via requisição PUT.

Adição do tratamento de exceção para casos em que a ONG não seja encontrada pelo ID.

**Motivação:**

A implementação visa melhorar a performance na atualização do status, evitando a carga completa da entidade e reduzindo a quantidade de operações no banco.

**Testes Realizados:**

Testes manuais realizados para verificar o comportamento da rota em diferentes cenários:

ID válido com status true.

ID válido com status false.

ID inexistente no banco.